### PR TITLE
Remove target="_blank" and replace Google+ with LinkedIn

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
         {% else %}
         {% assign domain = site.url %}
       {% endif %}
-			<li><a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}target="_blank"{% endif %}>{{ link.title }}</a></li>
+			<li><a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}{% endif %}>{{ link.title }}</a></li>
 		{% endfor %}
 		</ul>
 	</nav><!-- /.bottom-menu -->

--- a/_includes/navigation-sliding.html
+++ b/_includes/navigation-sliding.html
@@ -7,7 +7,7 @@
       {% else %}
         {% assign domain = site.url %}
       {% endif %}
-      <a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}target="_blank"{% endif %}>
+      <a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}{% endif %}>
           <div class="title">{{ link.title }}</div>
           {% if link.excerpt %}<p class="excerpt">{{ link.excerpt }}</p>{% endif %}
       </a>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,7 +6,7 @@
         {% assign domain = site.url %}
     {% endif %}
     <li>
-      <a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}target="_blank"{% endif %}>{{ link.title }}</a>
+      <a href="{{ domain }}{{ link.url }}" {% if link.url contains 'http' %}{% endif %}>{{ link.title }}</a>
       <span class="line"></span>
       <span class="line2"></span>
       <div class="circle"></div>

--- a/_includes/share-this.html
+++ b/_includes/share-this.html
@@ -1,5 +1,5 @@
 <div class="inline-btn">
 	<a class="btn-social twitter" href="https://twitter.com/intent/tweet?text={{ page.title | escape | replace:' ','%20' }}&amp;url={{ page.url | replace:'index.html','' | prepend: site.url }}&amp;via={{ site.owner.twitter }}" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i> {{ site.data.messages.locales[site.locale].share }} Twitter</a>
 	<a class="btn-social facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | replace:'index.html','' | prepend: site.url }}" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i> {{ site.data.messages.locales[site.locale].share }} Facebook</a>
-	<a class="btn-social google-plus"  href="https://plus.google.com/share?url={{ page.url | replace:'index.html','' | prepend: site.url }}" target="_blank"><i class="fa fa-google-plus" aria-hidden="true"></i> {{ site.data.messages.locales[site.locale].share }} Google+</a>
+  <a class="btn-social linkedin" href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ page.url | replace:'index.html','' | prepend: site.url }}&amp;title={{ page.title | escape | replace:' ','%20' }}&amp;source=C.H.%20Robinson%20Engineering%20Blog" target="_blank"><i class="fa fa-linkedin" aria-hidden="true"></i> {{ site.data.messages.locales[site.locale].share }} LinkedIn</a>
 </div><!-- /.share-this -->


### PR DESCRIPTION
All links (except for the sharing buttons) now open in the current window. Remove Google+ sharing button and add LinkedIn sharing button.